### PR TITLE
Fixed container width for result cards

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -37,3 +37,7 @@ h2{
     display: flex;
     justify-content: center;
 }
+
+.results {
+    width: 90%;
+}

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Find My Escape</title>
+  <title>Find Your Escape</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.3/css/bulma.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/pikaday@1.8.0/css/pikaday.min.css">


### PR DESCRIPTION
Default container width for the result cards is small. Set it to 90% of page. 